### PR TITLE
to_gradians.separator update ompy.py 0317 0123 pull

### DIFF
--- a/ompy.py
+++ b/ompy.py
@@ -316,14 +316,8 @@ def to_gradians(
                 "Requested numeric type and degrees, minutes, seconds pattern: D" +  
                 str(chr(176)) + "MM'SS'' or DdMM'SS''"
             )
-            
-        if str(chr(176)) in theta:
 
-            separator = str(chr(176))
-
-        else:
-
-            separator = "d"
+        separator = re.findall("[0-9]+[d"+str(chr(176))+"]", theta)[0][-1]
 
         sexagesimal = theta.split(separator)
         degrees = float(sexagesimal[0])
@@ -352,7 +346,7 @@ def to_gradians(
         return gradians
 
     else:
-         # Angle conversion from decimal degrees.
+        # Angle conversion from decimal degrees.
 
-         gradians = round(10 * theta / 9, 15)
-         return gradians
+        gradians = round(10 * theta / 9, 15)
+        return gradians


### PR DESCRIPTION
Updates / improvements on ompy.py:
- Upgrades according to PEP guidelines (indentation in to_gradians).
- Change on the local variable 'separator' in function 'to_gradians'; used as denoting the degrees 
on sexagesimal system in the provided angle 'theta'. 
Update from conditional block to defining one-liner.
From:

        if str(chr(176)) in theta:

            separator = str(chr(176))

        else:

            separator = "d"

to:

         separator = re.findall("[0-9]+[d"+str(chr(176))+"]", theta)[0][-1]
