### PR TITLE
optional exception handling for to_gradians in from_sexagesimal

### DIFF
--- a/ompy.py
+++ b/ompy.py
@@ -305,14 +305,20 @@ def to_gradians(
 
     if from_sexagesimal:
         # Angle conversion from sexagesimal angle measurement (degrees, minutes and seconds).
-        
-        if type(theta) != str or not re.fullmatch(
+
+        if type(theta):
+
+            raise TypeError(
+                "Class type not supported; str expected."
+            )
+
+        if not re.fullmatch(
             "[0-9]+[d" + str(chr(176)) + "][0-5][0-9]'[0-5][0-9]([.][0-9]*)*''", theta
         ):
-          
-            raise TypeError(
+            
+            raise ValueError(
                 "Angle " + str(theta) +  
-                " class type not supported; not matching correct format or out of numeric range. " + 
+                " not matching correct format or out of numeric range. " + 
                 "Requested numeric type and degrees, minutes, seconds pattern: D" +  
                 str(chr(176)) + "MM'SS'' or DdMM'SS''"
             )
@@ -350,4 +356,4 @@ def to_gradians(
         # Angle conversion from decimal degrees.
 
         gradians = round(10 * theta / 9, 15)
-        return gradians
+        return gradians 


### PR DESCRIPTION
Optional exception handling on ompy.py 0318 1030:

If angle not 'str' type, a customized-message exception will be raised.
        
        ...
        if type(theta) != str:
            
                raise TypeError(
                        "Class type not supported; str expected."
                )
        '''

Current code skip this block due to the following exception-handling block which checks if angle fits the str regex pattern required, 
(condition of being string has to be met).

        ...
        if not re.fullmatch(
                "[0-9]+[d" + str(chr(176)) + "][0-5][0-9]'[0-5][0-9]([.][0-9]*)*''", theta
        ):
            
                raise ValueError(
                        "Angle " + str(theta) +  
                        " not matching correct format or out of numeric range. " + 
                        "Requested numeric type and degrees, minutes, seconds pattern: D" +  
                        str(chr(176)) + "MM'SS'' or DdMM'SS''"
                )

 Also, because the error message from re library transmits the same information it does above.

        >>>to_gradians(1, from_sexagesimal=True)
        TypeError:                            Traceback (most recent call last)
        /usr/lib/python3.7/re.py in fullmatch(pattern, string, flags)
          178     """Try to apply the pattern to all of the string, returning
          179     a Match object, or None if no match was found."""
       -> 180     return _compile(pattern, flags).fullmatch(string)
          181 
              182 def search(pattern, string, flags=0):

        TypeError: expected string or bytes-like object
        