### PR TITLE
to_gradians function exception handling in from_sexagesimal pull

### DIFF
--- a/ompy.py
+++ b/ompy.py
@@ -306,12 +306,6 @@ def to_gradians(
     if from_sexagesimal:
         # Angle conversion from sexagesimal angle measurement (degrees, minutes and seconds).
 
-        if type(theta):
-
-            raise TypeError(
-                "Class type not supported; str expected."
-            )
-
         if not re.fullmatch(
             "[0-9]+[d" + str(chr(176)) + "][0-5][0-9]'[0-5][0-9]([.][0-9]*)*''", theta
         ):

--- a/ompy.py
+++ b/ompy.py
@@ -305,14 +305,20 @@ def to_gradians(
 
     if from_sexagesimal:
         # Angle conversion from sexagesimal angle measurement (degrees, minutes and seconds).
-        
-        if type(theta) != str or not re.fullmatch(
+
+        if type(theta):
+
+            raise TypeError(
+                "Class type not supported; str expected."
+            )
+
+        if not re.fullmatch(
             "[0-9]+[d" + str(chr(176)) + "][0-5][0-9]'[0-5][0-9]([.][0-9]*)*''", theta
         ):
-          
-            raise TypeError(
+            
+            raise ValueError(
                 "Angle " + str(theta) +  
-                " class type not supported; not matching correct format or out of numeric range. " + 
+                " not matching correct format or out of numeric range. " + 
                 "Requested numeric type and degrees, minutes, seconds pattern: D" +  
                 str(chr(176)) + "MM'SS'' or DdMM'SS''"
             )
@@ -350,4 +356,4 @@ def to_gradians(
         # Angle conversion from decimal degrees.
 
         gradians = round(10 * theta / 9, 15)
-        return gradians
+        return gradians 


### PR DESCRIPTION
Updates/improvements on ompy.py 0318 1106:

Instead of checking both type(theta) and regex pattern, 
        if type(theta) ot not re.fullmatch(
                "[0-9]+[d" + str(chr(176)) + "][0-5][0-9]'[0-5][0-9]([.][0-9]*)*''", theta
        ):
            
                raise ValueError(
                        "Angle " + str(theta) +  
                        " class type not supported; not matching correct format or out of numeric range. " + 
                        "Requested numeric type and degrees, minutes, seconds pattern: D" +  
                        str(chr(176)) + "MM'SS'' or DdMM'SS''"
                )

only the regex match will be tested.

 if not re.fullmatch(
            "[0-9]+[d" + str(chr(176)) + "][0-5][0-9]'[0-5][0-9]([.][0-9]*)*''", theta
        ):
            
            raise ValueError(
                "Angle " + str(theta) +  
                " not matching correct format or out of numeric range. " + 
                "Requested numeric type and degrees, minutes, seconds pattern: D" +  
                str(chr(176)) + "MM'SS'' or DdMM'SS''"
            )

The conditions in the former code were redundant, since to be pattern-matching has to be str already.
If ```from_sexagesimal=True``` and ```theta not str```, an exception directly from re module will be output.

        >>>to_gradians(1, from_sexagesimal=True)
        TypeError:                            Traceback (most recent call last)
        /usr/lib/python3.7/re.py in fullmatch(pattern, string, flags)
          178     """Try to apply the pattern to all of the string, returning
          179     a Match object, or None if no match was found."""
       -> 180     return _compile(pattern, flags).fullmatch(string)
          181 
              182 def search(pattern, string, flags=0):

        TypeError: expected string or bytes-like object

An optional / alternative exception handling is proposed in previous pull request from this one,
were the case ```theta not str``` was customized in the following message: ```"Class type not supported; str expected."```:

[optional exception handling for to_gradians in from_sexagesimal](https://github.com/AlejandroPenaloza/ompy/pull/33)
