### PR TITLE
change logical correct indentation ) in function to_dec_degrees commit

### DIFF
--- a/ompy.py
+++ b/ompy.py
@@ -41,8 +41,8 @@ def to_dec_degrees(
     from_sexagesimal=False, 
     from_gradians=False, 
     from_turns=False
-    ):
-  
+):
+
     """
     It takes an angle given in the following units: degrees-minutes-seconds,
     radians, gradians and turns; and returns the angle converted in decimal degrees.


### PR DESCRIPTION
0318 2153
Updates / improvements on ompy.py:

Deletion of blank spaces which did not locate the defining function ending in the correct logical place.

        ...
        def to_dec_degrees(
                theta, 
                from_radians=True, 
                from_sexagesimal=False, 
                from_gradians=False, 
                from_turns=False

from:

                ):
        ...

to:

        ):
       ...
