### PR TITLE
change if statements into to_gradians function pull

### DIFF
--- a/ompy.py
+++ b/ompy.py
@@ -306,7 +306,7 @@ def to_gradians(
                 "Class type not supported; 'str' angle required."
             )
 
-        elif not re.fullmatch(
+        if not re.fullmatch(
             "[0-9]+[d" + str(chr(176)) + "][0-5][0-9]'[0-5][0-9]([.][0-9]*)*''", theta
         ):
             


### PR DESCRIPTION
Updates/improvements on ompy.py 0327 2212:

Change inside function ```to_gradians``` if the current angle unit to convert from is sexagesimal, on if-elif statements.
Shown as follows:

         ...
         if from_sexagesimal:
        # Angle conversion from sexagesimal angle measurement (degrees, minutes and seconds).

                if type(theta) != str:
                        raise TypeError(
                        "Class type not supported; 'str' angle required."
                )

                if not re.fullmatch(
                        "[0-9]+[d" + str(chr(176)) + "][0-5][0-9]'[0-5][0-9]([.][0-9]*)*''", theta
                ):
         ...   

As after the first ```if``` statement an error is raised (code stop running) or it keeps on the next statement so ```theta``` is tested.
Instead of of-elif, if-if makes more sense.