### PR TITLE
not str input exception message change in to_gradians function pull

### DIFF
--- a/ompy.py
+++ b/ompy.py
@@ -303,7 +303,7 @@ def to_gradians(
 
         if type(theta) != str:
             raise TypeError(
-                "Class type not supported; 'str' angle required."
+                "Class type not supported; 'str' expected."
             )
 
         if not re.fullmatch(


### PR DESCRIPTION
###Updates/improvements on ompy.py 0327 2231:

Change of message in exception raise when function ```to_gradians``` is called passing ```theta``` angle type not ```str``` and unit to convert from is sexagesimal.

From:

         ...
         if from_sexagesimal:
        # Angle conversion from sexagesimal angle measurement (degrees, minutes and seconds).

                if type(theta) != str:
                    raise TypeError(
                        "Class type not supported; 'str' angle required."
                )
         ...

To:

         ...
         if from_sexagesimal:
        # Angle conversion from sexagesimal angle measurement (degrees, minutes and seconds).

                if type(theta) != str:
                    raise TypeError(
                        "Class type not supported; 'str' expected."
                )
       ...