### PR TITLE
better readibility docstring in are_bools func pull

### DIFF
--- a/ompy.py
+++ b/ompy.py
@@ -14,6 +14,7 @@ def are_bools(tuple_arg):
 
     """
     #### are_bool
+    
     - param: tuple_arg (tuple).
     - returns: True if all items in tuple_arg are booleans. False otherwise.
     """


### PR DESCRIPTION
Updates/improvements on ompy.py 0328 1341:

Just  adding a blank line inside function ```are_bools``` docstrings, where it is explained what its parameters and object returned.
 
        ...
        def are_bools(tuple_arg):

        """
        #### are_bool

        - param: tuple_arg (tuple).
        - returns: True if all items in tuple_arg are booleans. False otherwise.
        """
        ...
