### PR TITLE
importing exceptions into ompy.py pull

### DIFF
--- a/ompy.py
+++ b/ompy.py
@@ -7,6 +7,8 @@ import inspect
 from decimal import Decimal
 from collections import defaultdict
 
+import .exceptions
+
 
 def are_bools(tuple_arg):
 


### PR DESCRIPTION
### Updates/improvements on ompy.py 0410 1510:

-   Importing `exceptions` which corresponds to the **exceptions.py** file in repository where all custom exceptions are defined.
It is just a heads-up, as it is not used yet, but it will on the following commits.