### PR TITLE
SexagesimalFaetureError inclusion on exceptions.py and ompy.py pull

### DIFF
--- a/exceptions.py
+++ b/exceptions.py
@@ -11,5 +11,9 @@ class UnitError(Exception):
         super().__init__(self.message)
 
 
-class SexagesimalError(Exception):
+class SexagesimalError(UnitError):
+    pass
+
+
+class SexagesimalFeatureError(SexagesimalError):
     pass

--- a/ompy.py
+++ b/ompy.py
@@ -7,7 +7,7 @@ import inspect
 from decimal import Decimal
 from collections import defaultdict
 
-import .exceptions
+from .exceptions import SexagesimalFeatureError
 
 
 def are_bools(tuple_arg):
@@ -643,12 +643,12 @@ def to_sexagesimal(
         seconds,
     )
 
-    KeyError_msg = "Key unavailable; only sexagesimal features str, tuple, 'degrees', 'minutes' and 'seconds' expected."
+    SexagesimalFeatureError_msg = "Key unavailable; only sexagesimal unit features str, tuple, 'degrees', 'minutes' and 'seconds' expected."
 
 
     def sexagesimal_default_factory(): 
 
-        raise KeyError(KeyError_msg)
+        raise SexagesimalFeatureError(SexagesimalFeatureError_msg)
 
 
     sexagesimal = defaultdict(sexagesimal_default_factory)


### PR DESCRIPTION
### Updates/Improvements on **exceptions.py** and **ompy.py** 0412 1222:

-    Creation of `exception class SexagesimalFeatureError` which inherits from `exception class SexagesimalError`, in **exceptions.py**.

    ...
    class SexagesimalFeatureError(SexagesimalError):
        ...

-    Inclusion of `SexagesimalFeatureError` used into `to_sexagesimal` function to raise exception in case wrong key is used with returning defaultdict (`KeyError`), in **ompy.py**.
    
    ...    
    SexagesimalFeatureError_msg = "Key unavailable; only sexagesimal unit features str, tuple, 'degrees', 'minutes' and 'seconds' 
    expected."


    def sexagesimal_default_factory(): 

         raise SexagesimalFeatureError(SexagesimalFeatureError_msg)


    sexagesimal = defaultdict(sexagesimal_default_factory)
    ...
