### PR TITLE
namedtuple name changing in to_sexagesimal pull

### DIFF
--- a/ompy.py
+++ b/ompy.py
@@ -644,7 +644,7 @@ def to_sexagesimal(
     sexagesimal_str = f"{degrees}{chr(176)}{minutes}'{seconds}''"
 
     sexagesimal_angle_features = namedtuple(
-        "sexagesimal_angle_features",
+        "SexagesimalAngle",
         f"str_ "
         f"degrees "
         f"minutes "


### PR DESCRIPTION
Updates/improvements on ompy.py 0505 1247:

-   Change on `sexagesimal_angle_features` object which is the returning namedtuple on function `to_sexgaesimal`, with former name `sexagesimal_angle_features`, now `SexagesimalAngle`.

        ...
        sexagesimal_angle_features = namedtuple(
            "SexagesimalAngle",
            f"str_ "
            f"degrees "
            f"minutes "
            f"seconds",
            module="sexagesimal"
        )
        ...

Ex:     
    
          >>> from ompy.ompy import *
          >>> to_sexagesimal(-87.1234, from_dec_degrees=True)
          SexagesimalAngle(str_="-87°7'24.24''", degrees=-87, minutes=7, seconds=24.24)

    