### PR TITLE
removing sympy module import 909 0105 pull

### DIFF
--- a/ompy.py
+++ b/ompy.py
@@ -1,6 +1,5 @@
 import re
 import numpy as np
-import sympy
 import traceback
 import inspect
 from fractions import Fraction


### PR DESCRIPTION
Updates/improvements on ompy.py 909 0105:

-   Stop importing "Sympy".